### PR TITLE
install toml explicitly in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install strictdoc
+          python -m pip install toml
           python -m pip install pygments
 
       - name: Run Strict Doc


### PR DESCRIPTION
should fix the build here on new strictdoc versions. worked here: https://github.com/nmfta-repo/vcr-experiment/pull/2