### PR TITLE
workflows: don't publish PR changes to gh-pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: Cecilapp/GitHub-Pages-deploy@v3
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
i noticed PR changes were getting published to the gh-pages browsable. That's not desirable (in vcr-experiment at least). c.f. https://github.com/nmfta-repo/vcr-experiment/pull/10